### PR TITLE
feat: refactor le service de traduction pour utiliser deep-translator…

### DIFF
--- a/app/services/translation_service.py
+++ b/app/services/translation_service.py
@@ -42,6 +42,7 @@ class TranslationService:
             logger.info("Traducteur initialisé avec succès")
         except Exception as e:
             logger.error("Erreur lors de l'initialisation du traducteur: %s", e)
+            self._translator = None  # Réinitialisation du translator en cas d'erreur
             raise
 
     @property

--- a/app/services/translation_service.py
+++ b/app/services/translation_service.py
@@ -70,18 +70,17 @@ class TranslationService:
         Raises:
             RuntimeError: Si le traducteur n'est pas initialisé
         """
-        if not self.is_loaded:
+        # Si le traducteur n'est pas chargé ou si les langues sont différentes,
+        # on l'initialise avec les nouvelles langues
+        if not self.is_loaded or (
+            self._translator and (
+                source_lang != self._translator.source
+                or target_lang != self._translator.target
+            )
+        ):
             self.load_model(source_lang, target_lang)
 
         try:
-            if (
-                source_lang != self._translator.source
-                or target_lang != self._translator.target
-            ):
-                self._translator = GoogleTranslator(
-                    source=source_lang, target=target_lang
-                )
-
             return self._translator.translate(text)
         except Exception as e:
             logger.error("Erreur lors de la traduction: %s", e)

--- a/app/services/translation_service.py
+++ b/app/services/translation_service.py
@@ -66,14 +66,11 @@ class TranslationService:
 
         Returns:
             str: Texte traduit
-
-        Raises:
-            RuntimeError: Si le traducteur n'est pas initialisé
         """
-        # Si le traducteur n'est pas chargé ou si les langues sont différentes,
-        # on l'initialise avec les nouvelles langues
+        # Initialisation automatique du traducteur si nécessaire
         if not self.is_loaded or (
-            self._translator and (
+            self._translator
+            and (
                 source_lang != self._translator.source
                 or target_lang != self._translator.target
             )

--- a/poetry.lock
+++ b/poetry.lock
@@ -35,6 +35,29 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.13.3"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.7.0"
+groups = ["main"]
+files = [
+    {file = "beautifulsoup4-4.13.3-py3-none-any.whl", hash = "sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16"},
+    {file = "beautifulsoup4-4.13.3.tar.gz", hash = "sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+typing-extensions = ">=4.0.0"
+
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "24.10.0"
 description = "The uncompromising code formatter."
@@ -487,6 +510,27 @@ sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["certifi (>=2024)", "cryptography-vectors (==44.0.2)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "deep-translator"
+version = "1.11.4"
+description = "A flexible free and unlimited python tool to translate between different languages in a simple way using multiple translators"
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["main"]
+files = [
+    {file = "deep_translator-1.11.4-py3-none-any.whl", hash = "sha256:d635df037e23fa35d12fd42dab72a0b55c9dd19e6292009ee7207e3f30b9e60a"},
+    {file = "deep_translator-1.11.4.tar.gz", hash = "sha256:801260c69231138707ea88a0955e484db7d40e210c9e0ae0f77372ffda5f4bf5"},
+]
+
+[package.dependencies]
+beautifulsoup4 = ">=4.9.1,<5.0.0"
+requests = ">=2.23.0,<3.0.0"
+
+[package.extras]
+ai = ["openai (>=0.27.6,<0.28.0) ; python_full_version >= \"3.7.1\" and python_full_version < \"4.0.0\""]
+docx = ["docx2txt (>=0.8,<0.9)"]
+pdf = ["pypdf (>=3.3.0,<4.0.0)"]
 
 [[package]]
 name = "faiss-cpu"
@@ -2225,6 +2269,18 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.6"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"},
+    {file = "soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"},
+]
+
+[[package]]
 name = "starlette"
 version = "0.37.2"
 description = "The little ASGI library that shines."
@@ -2574,4 +2630,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12.9"
-content-hash = "8cc4153c29ce7333a4b0c3df75cd58f0038e9b02567a406be85c03699658edcb"
+content-hash = "3eea92b930ab469247bb6653c54a57d7ae9956d53f19171807680be19a6e2670"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ pytest-mock = "^3.14.0"
 boto = "^2.49.0"
 pyjwt = "^2.10.1"
 sentencepiece = "^0.2.0"
-transformers = "^4.50.3"
 langid = "^1.1.6"
+deep-translator = "^1.11.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.2"

--- a/tests/services/test_translation_service.py
+++ b/tests/services/test_translation_service.py
@@ -5,6 +5,16 @@ from unittest.mock import patch, MagicMock
 from app.services.translation_service import TranslationService
 
 
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Fixture pour réinitialiser le singleton avant chaque test."""
+    TranslationService._instance = None
+    TranslationService._translator = None
+    yield
+    TranslationService._instance = None
+    TranslationService._translator = None
+
+
 @pytest.fixture
 def translation_service():
     """Fixture pour le service de traduction."""

--- a/tests/services/test_translation_service.py
+++ b/tests/services/test_translation_service.py
@@ -1,0 +1,118 @@
+"""Tests pour le service de traduction."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from app.services.translation_service import TranslationService
+
+
+@pytest.fixture
+def translation_service():
+    """Fixture pour le service de traduction."""
+    # Réinitialiser le singleton entre chaque test
+    TranslationService._instance = None
+    TranslationService._translator = None
+    return TranslationService.get_instance()
+
+
+def test_singleton_pattern():
+    """Test du pattern singleton."""
+    service1 = TranslationService.get_instance()
+    service2 = TranslationService.get_instance()
+    assert service1 is service2
+
+
+def test_is_loaded_false_by_default():
+    """Test que le traducteur n'est pas chargé par défaut."""
+    service = TranslationService.get_instance()
+    assert not service.is_loaded
+
+
+@patch('app.services.translation_service.GoogleTranslator')
+def test_load_model(mock_translator):
+    """Test du chargement du modèle."""
+    service = TranslationService.get_instance()
+    service.load_model()
+
+    mock_translator.assert_called_once_with(source='auto', target='en')
+    assert service.is_loaded
+
+
+@patch('app.services.translation_service.GoogleTranslator')
+def test_load_model_with_custom_langs(mock_translator):
+    """Test du chargement du modèle avec des langues personnalisées."""
+    service = TranslationService.get_instance()
+    service.load_model(source_lang='fr', target_lang='es')
+
+    mock_translator.assert_called_once_with(source='fr', target='es')
+    assert service.is_loaded
+
+
+@patch('app.services.translation_service.GoogleTranslator')
+def test_load_model_error_handling(mock_translator):
+    """Test de la gestion des erreurs lors du chargement du modèle."""
+    mock_translator.side_effect = Exception("Test error")
+    service = TranslationService.get_instance()
+
+    with pytest.raises(Exception):
+        service.load_model()
+
+    assert not service.is_loaded
+
+
+@patch('app.services.translation_service.GoogleTranslator')
+def test_translate_loads_model_if_needed(mock_translator):
+    """Test que la traduction charge le modèle si nécessaire."""
+    mock_instance = MagicMock()
+    mock_instance.translate.return_value = "Hello world"
+    mock_translator.return_value = mock_instance
+
+    service = TranslationService.get_instance()
+    result = service.translate("Bonjour monde")
+
+    assert result == "Hello world"
+    mock_translator.assert_called_once()
+    mock_instance.translate.assert_called_once_with("Bonjour monde")
+
+
+@patch('app.services.translation_service.GoogleTranslator')
+def test_translate_with_different_languages(mock_translator):
+    """Test de la traduction avec différentes langues."""
+    mock_instance = MagicMock()
+    mock_instance.translate.return_value = "Hola mundo"
+    mock_translator.return_value = mock_instance
+
+    service = TranslationService.get_instance()
+    result = service.translate("Hello world", source_lang='en', target_lang='es')
+
+    assert result == "Hola mundo"
+    mock_translator.assert_called_with(source='en', target='es')
+
+
+@patch('app.services.translation_service.GoogleTranslator')
+def test_translate_error_handling(mock_translator):
+    """Test de la gestion des erreurs lors de la traduction."""
+    mock_instance = MagicMock()
+    mock_instance.translate.side_effect = Exception("Translation error")
+    mock_translator.return_value = mock_instance
+
+    service = TranslationService.get_instance()
+    original_text = "Test text"
+    result = service.translate(original_text)
+
+    assert result == original_text  # Retourne le texte original en cas d'erreur
+
+
+@patch('app.services.translation_service.GoogleTranslator')
+def test_translate_updates_translator_if_languages_change(mock_translator):
+    """Test que le traducteur est mis à jour si les langues changent."""
+    mock_instance1 = MagicMock(source='auto', target='en')
+    mock_instance2 = MagicMock(source='fr', target='es')
+    mock_translator.side_effect = [mock_instance1, mock_instance2]
+
+    service = TranslationService.get_instance()
+    service.translate("Test")  # Premier appel avec langues par défaut
+    service.translate("Test", source_lang='fr', target_lang='es')  # Second appel avec nouvelles langues
+
+    assert mock_translator.call_count == 2
+    mock_translator.assert_any_call(source='auto', target='en')
+    mock_translator.assert_any_call(source='fr', target='es')


### PR DESCRIPTION
This pull request updates the `TranslationService` to use the `deep-translator` library instead of `transformers` and adds comprehensive tests for the translation functionality. The most important changes include modifications to the translation service implementation, updates to dependencies, and the addition of new tests.

**Translation Service Updates:**

* [`app/services/translation_service.py`](diffhunk://#diff-63c6b72b7c3be6a08645bce3785ef7e288c920b017f69fa70e20ba7ad53bc4b4L1-R17): Replaced `transformers` with `deep-translator` for translation, simplified the translation model initialization, and added a new `translate` method. [[1]](diffhunk://#diff-63c6b72b7c3be6a08645bce3785ef7e288c920b017f69fa70e20ba7ad53bc4b4L1-R17) [[2]](diffhunk://#diff-63c6b72b7c3be6a08645bce3785ef7e288c920b017f69fa70e20ba7ad53bc4b4L32-R87)

**Dependency Updates:**

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L23-R24): Added `deep-translator` dependency and removed `transformers`.

**Testing Enhancements:**

* [`tests/services/test_translation_service.py`](diffhunk://#diff-e87eb21efd7719cb5b6a3cd2f155aff83abc553425ec9fda37bd94326e14131fR1-R118): Added new tests to cover singleton pattern, model loading, error handling, and translation functionality with different languages.